### PR TITLE
Support legacy event option for VintageNet

### DIFF
--- a/lib/property_table.ex
+++ b/lib/property_table.ex
@@ -23,8 +23,12 @@ defmodule PropertyTable do
 
   * `:name` - the name for the PropertyTable
   * `:properties` - an initial set of properties to load into the table
+  * `:tuple_events` - set to `true` to send change messages as tuple. Do not
+    use this. It is a transitional feature to help modify existing code to use
+    this library.
   """
-  @type option() :: {:name, table_id()} | {:properties, [property_value()]}
+  @type option() ::
+          {:name, table_id()} | {:properties, [property_value()]} | {:tuple_events, boolean()}
 
   @spec start_link([option()]) :: Supervisor.on_start()
   defdelegate start_link(options), to: PropertyTable.Supervisor

--- a/lib/property_table.ex
+++ b/lib/property_table.ex
@@ -18,9 +18,15 @@ defmodule PropertyTable do
   @type value :: any()
   @type property_value :: {property(), value()}
 
-  @type options :: [name: table_id(), properties: [property_value()]]
+  @typedoc """
+  PropertyTable configuration options
 
-  @spec start_link(options()) :: {:ok, pid} | {:error, term}
+  * `:name` - the name for the PropertyTable
+  * `:properties` - an initial set of properties to load into the table
+  """
+  @type option() :: {:name, table_id()} | {:properties, [property_value()]}
+
+  @spec start_link([option()]) :: Supervisor.on_start()
   defdelegate start_link(options), to: PropertyTable.Supervisor
 
   @doc """

--- a/lib/property_table/supervisor.ex
+++ b/lib/property_table/supervisor.ex
@@ -1,8 +1,29 @@
 defmodule PropertyTable.Supervisor do
-  @moduledoc false
+  @moduledoc """
+  Supervisor for using a PropertyTable
+
+  To create a PropertyTable for your application or library, add the following
+  `child_spec` to one of your supervision trees:
+
+  ```elixir
+  {PropertyTable.Supervisor, name: MyTableName}
+  ```
+
+  The `:name` option is required. All calls to `PropertyTable` will need to
+  know it. Other options are:
+
+  * `:properties` - a list of `{property, value}` tuples to initially populate
+  the `PropertyTable`
+  """
   use Supervisor
 
-  @spec start_link(PropertyTable.options()) :: Supervisor.on_start()
+  @doc """
+  Manually start a PropertyTable Supervisor
+
+  Normally you should add a `child_spec` to your supervision tree to create a
+  new `PropertyTable`.
+  """
+  @spec start_link([PropertyTable.option()]) :: Supervisor.on_start()
   def start_link(options) do
     name = Keyword.get(options, :name)
 
@@ -18,17 +39,19 @@ defmodule PropertyTable.Supervisor do
     name = Keyword.fetch!(options, :name)
     properties = Keyword.get(options, :properties, [])
     registry_name = registry_name(name)
+    updated_options = Keyword.put(options, :registry_name, registry_name)
 
     PropertyTable.Table.create_ets_table(name, properties)
 
     children = [
-      {PropertyTable.Table, {name, registry_name}},
+      {PropertyTable.Table, updated_options},
       {Registry, [keys: :duplicate, name: registry_name]}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)
   end
 
+  @doc false
   @spec registry_name(PropertyTable.table_id()) :: Registry.registry()
   def registry_name(name) do
     Module.concat(PropertyTable.Registry, name)

--- a/lib/property_table/table.ex
+++ b/lib/property_table/table.ex
@@ -22,9 +22,9 @@ defmodule PropertyTable.Table do
     end)
   end
 
-  @spec start_link({PropertyTable.table_id(), Registry.registry()}) :: GenServer.on_start()
-  def start_link({table, _registry_name} = args) do
-    GenServer.start_link(__MODULE__, args, name: table)
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: opts[:name])
   end
 
   @spec get(PropertyTable.table_id(), PropertyTable.property(), PropertyTable.value()) ::
@@ -124,8 +124,8 @@ defmodule PropertyTable.Table do
   end
 
   @impl GenServer
-  def init({table, registry_name}) do
-    {:ok, %{table: table, registry: registry_name}}
+  def init(opts) do
+    {:ok, %{table: opts[:name], registry: opts[:registry_name]}}
   end
 
   @impl GenServer

--- a/test/property_table_test.exs
+++ b/test/property_table_test.exs
@@ -280,4 +280,13 @@ defmodule PropertyTableTest do
     assert previous_timestamp == event_previous_timestamp
     assert timestamp == event_timestamp
   end
+
+  test "sending the old tuple events", %{test: table} do
+    {:ok, _pid} = start_supervised({PropertyTable, name: table, tuple_events: true})
+    property = ["test", "a", "b"]
+
+    PropertyTable.subscribe(table, [])
+    PropertyTable.put(table, property, 101)
+    assert_receive {^table, ^property, nil, 101, %{old_timestamp: _, new_timestamp: _}}
+  end
 end


### PR DESCRIPTION
- Use keyword list for options; cleanup docs
- Support old tuple-style events
