### PR TITLE
Minor optimization to dispatch

### DIFF
--- a/lib/property_table/table.ex
+++ b/lib/property_table/table.ex
@@ -227,7 +227,7 @@ defmodule PropertyTable.Table do
 
     Registry.match(state.registry, :subscriptions, :_)
     |> Enum.each(fn {pid, match} ->
-      is_property_prefix_match?(match, property) && send(pid, message)
+      is_property_prefix_match?(match, property) and send(pid, message)
     end)
   end
 


### PR DESCRIPTION
Replace use of `&&` with `and`. The former is a `case`..`do` with a
match (see
https://github.com/elixir-lang/elixir/blob/v1.13.4/lib/elixir/lib/kernel.ex#L3925-L3931)
and the latter is one call to `:erlang.andalso`. See
https://github.com/elixir-lang/elixir/blob/v1.13.4/lib/elixir/lib/kernel.ex#L1824.

The left side is the only side that needs to be boolean, so this works.
It results in a small performance improvement since it's in the critical
dispatch loop.
