### PR TITLE
Standardize all GenServer naming on the table name

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,26 @@ NetworkTable
     └── :internet
 ```
 
-And inserting the values to the table would look like:
+PropertyTables are either used by libraries to share status information or you
+can create your own. A common use case is that the code that creates the
+PropertyTable will manage the properties in the table. All other code reads
+property values or subscribes to changes.
+
+Creating a PropertyTable is either done by adding a `child_spec` to a
+supervision tree:
+
+```elixir
+{PropertyTable, name: NetworkTable}
+```
+
+Or manually calling `PropertyTable.start_link/1`. If you're at an IEx prompt,
+run the following so that you can follow along with the rest of the examples:
+
+```elixir
+PropertyTable.start_link(name: NetworkTable)
+```
+
+Inserting values into the table looks like:
 
 ```elixir
 PropertyTable.put(NetworkTable, ["available_interfaces"], ["eth0", "eth1"])

--- a/lib/property_table/supervisor.ex
+++ b/lib/property_table/supervisor.ex
@@ -1,51 +1,22 @@
 defmodule PropertyTable.Supervisor do
-  @moduledoc """
-  Supervisor for using a PropertyTable
-
-  To create a PropertyTable for your application or library, add the following
-  `child_spec` to one of your supervision trees:
-
-  ```elixir
-  {PropertyTable.Supervisor, name: MyTableName}
-  ```
-
-  The `:name` option is required. All calls to `PropertyTable` will need to
-  know it. Other options are:
-
-  * `:properties` - a list of `{property, value}` tuples to initially populate
-  the `PropertyTable`
-  """
+  @moduledoc false
   use Supervisor
-
-  @doc """
-  Manually start a PropertyTable Supervisor
-
-  Normally you should add a `child_spec` to your supervision tree to create a
-  new `PropertyTable`.
-  """
-  @spec start_link([PropertyTable.option()]) :: Supervisor.on_start()
-  def start_link(options) do
-    name = Keyword.get(options, :name)
-
-    unless !is_nil(name) and is_atom(name) do
-      raise ArgumentError, "expected :name to be given and to be an atom, got: #{inspect(name)}"
-    end
-
-    Supervisor.start_link(__MODULE__, options)
-  end
 
   @impl Supervisor
   def init(options) do
-    name = Keyword.fetch!(options, :name)
-    properties = Keyword.get(options, :properties, [])
-    registry_name = registry_name(name)
-    updated_options = Keyword.put(options, :registry_name, registry_name)
+    registry_name = registry_name(options.table)
 
-    PropertyTable.Table.create_ets_table(name, properties)
+    table_options = %{
+      registry: registry_name,
+      table: options.table,
+      tuple_events: options.tuple_events
+    }
+
+    PropertyTable.Table.create_ets_table(options.table, options.properties)
 
     children = [
-      {PropertyTable.Table, updated_options},
-      {Registry, [keys: :duplicate, name: registry_name]}
+      {PropertyTable.Table, table_options},
+      {Registry, [keys: :duplicate, name: registry_name, partitions: 1]}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)
@@ -54,6 +25,6 @@ defmodule PropertyTable.Supervisor do
   @doc false
   @spec registry_name(PropertyTable.table_id()) :: Registry.registry()
   def registry_name(name) do
-    Module.concat(PropertyTable.Registry, name)
+    Module.concat(name, Subscriptions)
   end
 end

--- a/test/property_table_test.exs
+++ b/test/property_table_test.exs
@@ -36,7 +36,8 @@ defmodule PropertyTableTest do
     # Crash the table. Due to async process crash and recovery if there isn't a
     # sleep here, the asserts can run before the crash and pass without testing
     # recovery.
-    Process.exit(Process.whereis(table), :oops)
+    table_genserver = PropertyTable.Table.server_name(table)
+    Process.exit(Process.whereis(table_genserver), :oops)
     Process.sleep(10)
 
     # Test that the properties didn't get lost or overwritten


### PR DESCRIPTION
This moves the public API for starting a PropertyTable completely to
`property_table.ex`. It also changes the names in the process tree so
that users are adding to their namespace rather than PropertyTable's. It
looks like this:

```
<table_name>
<table_name>.Registry
<table_name>.Table
```

The `<table_name>` process is the supervisor. If the user calls
`GenServer.stop` on it, everything goes down like you'd expect. This is
different from before. Previously the PropertyTable supervisor was
unnamed.

All parameter validation is in `PropertyTable.start_link/1`. The code in
`PropertyTable.Supervisor` is minimal now and it's been removed from the
public API.
