### PR TITLE
Extract match logic to its own module

### DIFF
--- a/lib/property_table/matcher.ex
+++ b/lib/property_table/matcher.ex
@@ -1,0 +1,77 @@
+defmodule PropertyTable.Matcher do
+  @moduledoc """
+  Match logic using keys organized as hierarchical lists
+
+  Property keys that are lists look like `["first", "second", "third"]`.
+  These are intended to create a hierarchical organization of keys. Matching
+  patterns involves checking whether the pattern is at the beginning of the
+  key. This makes it possible to get notified on every property change where
+  the key begins with `["first", "second"]`. This is a really common use case
+  when using hierarchically organized keys.
+
+  Two special atoms can be used:
+
+  * `:_` - match anything at this part of the list
+  * `:$` - match the end of the list
+  """
+
+  @doc """
+  Check whether a property is valid
+
+  Returns `:ok` on success or `{:error, error}` where `error` is an `Exception` struct with
+  information about the issue.
+  """
+  @spec check_property(PropertyTable.property()) :: :ok | {:error, Exception.t()}
+  def check_property([]), do: :ok
+
+  def check_property([part | rest]) when is_binary(part) do
+    check_property(rest)
+  end
+
+  def check_property([part | _]) do
+    {:error, ArgumentError.exception("Invalid property element '#{inspect(part)}'")}
+  end
+
+  def check_property(_other) do
+    {:error, ArgumentError.exception("Pattern should be a list of strings")}
+  end
+
+  @doc """
+  Check whether a pattern is valid
+
+  Returns `:ok` on success or `{:error, error}` where `error` is an `Exception` struct with
+  information about the issue.
+  """
+  @spec check_pattern(PropertyTable.pattern()) :: :ok | {:error, Exception.t()}
+  def check_pattern([]), do: :ok
+
+  def check_pattern([part | rest]) when is_binary(part) or part in [:_, :"$"] do
+    check_pattern(rest)
+  end
+
+  def check_pattern([part | _]) do
+    {:error, ArgumentError.exception("Invalid pattern element '#{inspect(part)}'")}
+  end
+
+  def check_pattern(_other) do
+    {:error, ArgumentError.exception("Pattern should be a list of strings or wildcard")}
+  end
+
+  @doc """
+  Returns true if the pattern matches the specified property
+  """
+  @spec match?(PropertyTable.pattern(), PropertyTable.property()) :: boolean()
+  def match?([], _property), do: true
+
+  def match?([value | match_rest], [value | property_rest]) do
+    __MODULE__.match?(match_rest, property_rest)
+  end
+
+  def match?([:_ | match_rest], [_any | property_rest]) do
+    __MODULE__.match?(match_rest, property_rest)
+  end
+
+  def match?([:"$"], []), do: true
+
+  def match?(_match, _property), do: false
+end

--- a/test/property_table/matcher_test.exs
+++ b/test/property_table/matcher_test.exs
@@ -1,0 +1,49 @@
+defmodule PropertyTable.MatcherTest do
+  use ExUnit.Case, async: true
+
+  alias PropertyTable.Matcher
+
+  doctest Matcher
+
+  test "check_property/1" do
+    assert :ok = Matcher.check_property([])
+    assert :ok = Matcher.check_property(["1"])
+    assert :ok = Matcher.check_property(["1", "2"])
+
+    assert {:error, _} = Matcher.check_property(nil)
+    assert {:error, _} = Matcher.check_property("1")
+
+    assert {:error, _} = Matcher.check_property([:_])
+    assert {:error, _} = Matcher.check_property([:"$"])
+    assert {:error, _} = Matcher.check_property(["1", :_])
+  end
+
+  test "check_pattern/1" do
+    assert :ok = Matcher.check_pattern([])
+    assert :ok = Matcher.check_pattern(["1"])
+    assert :ok = Matcher.check_pattern(["1", "2"])
+
+    assert {:error, _} = Matcher.check_pattern(nil)
+    assert {:error, _} = Matcher.check_pattern("1")
+
+    assert :ok = Matcher.check_pattern([:_])
+    assert :ok = Matcher.check_pattern([:"$"])
+    assert :ok = Matcher.check_pattern(["1", :_])
+    assert :ok = Matcher.check_pattern(["1", :"$"])
+  end
+
+  test "match/2" do
+    assert Matcher.match?(["1", "2"], ["1", "2"])
+    assert Matcher.match?(["1"], ["1", "2"])
+    assert Matcher.match?([], ["1", "2"])
+
+    assert Matcher.match?(["1", "2", :"$"], ["1", "2"])
+    refute Matcher.match?(["1", :"$"], ["1", "2"])
+
+    assert Matcher.match?([:_, "2"], ["1", "2"])
+    assert Matcher.match?(["1", :_], ["1", "2"])
+    assert Matcher.match?([:_, :_], ["1", "2"])
+    refute Matcher.match?([:_, "22"], ["1", "2"])
+    refute Matcher.match?(["11", :_], ["1", "2"])
+  end
+end


### PR DESCRIPTION
This is the first step in extracting the matching logic to its own
module. The goal is to make PropertyTable useful if you'd like to just
plain strings or maps for keys or if you'd like to have a custom
pattern matcher.
    
The one big change for hierarchical string lists is to make "prefix"
matching the default for everything. If you'd like to force the number
of fields in the property use the `:"$"` atom to signify that there
should be not more items in the property.