### PR TITLE
Support subscriptions on more than one pattern

### DIFF
--- a/lib/property_table.ex
+++ b/lib/property_table.ex
@@ -117,7 +117,7 @@ defmodule PropertyTable do
   @spec unsubscribe(table_id(), pattern()) :: :ok
   def unsubscribe(table, pattern) when is_list(pattern) do
     registry = PropertyTable.Supervisor.registry_name(table)
-    Registry.unregister(registry, :subscriptions)
+    Registry.unregister_match(registry, :subscriptions, pattern)
   end
 
   @doc """

--- a/test/property_table_test.exs
+++ b/test/property_table_test.exs
@@ -131,6 +131,37 @@ defmodule PropertyTableTest do
     assert PropertyTable.get_all(table, []) == []
   end
 
+  test "subscribing from one process to multiple patterns", %{test: table} do
+    {:ok, _pid} = start_supervised({PropertyTable, name: table})
+    property1 = ["test1"]
+    property2 = ["test2"]
+    property3 = ["test3"]
+    PropertyTable.subscribe(table, property1)
+    PropertyTable.subscribe(table, property2)
+
+    # Check that both subscriptions work
+    PropertyTable.put(table, property1, 99)
+    assert_receive %Event{table: ^table, property: ^property1, value: 99, previous_value: nil}
+
+    PropertyTable.put(table, property2, 100)
+    assert_receive %Event{table: ^table, property: ^property2, value: 100, previous_value: nil}
+
+    PropertyTable.put(table, property3, 101)
+    refute_receive _
+
+    # Check that unsubscribing to one doesn't stop notifications to the other
+    PropertyTable.unsubscribe(table, property1)
+
+    PropertyTable.clear(table, property1)
+    refute_receive _
+    PropertyTable.put(table, property2, 102)
+    assert_receive %Event{table: ^table, property: ^property2, value: 102, previous_value: 100}
+
+    PropertyTable.unsubscribe(table, property2)
+    PropertyTable.clear(table, property2)
+    refute_receive _
+  end
+
   test "generic subscribers receive events", %{test: table} do
     {:ok, _pid} = start_supervised({PropertyTable, name: table})
     property = ["test", "a", "b"]


### PR DESCRIPTION
This fixes an issue where if you subscribed to more than one pattern,
the first call to unsubscribe would unsubscribe everything.
