### PR TITLE
Remove special handling for nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ calling `PropertyTable.start_link/1`:
 PropertyTable.start_link(name: NetworkTable)
 ```
 
-Inserting values into the table looks like:
+Inserting properties into the table looks like:
 
 ```elixir
 PropertyTable.put(NetworkTable, ["available_interfaces"], ["eth0", "eth1"])
@@ -71,10 +71,6 @@ PropertyTable.put(NetworkTable, ["connection"], :internet)
 PropertyTable.put(NetworkTable, ["interface", "eth0", "config"], %{ipv4: %{method: :dhcp}})
 PropertyTable.put(NetworkTable, ["interface", "eth0", "connection"], :internet)
 ```
-
-Values can be any Elixir data structure except for `nil`. `nil` is used to
-identify non-existent properties. Therefore, setting a property to `nil` deletes
-the property. You can also call `PropertyTable.clear/2` to delete a property.
 
 Read one property by running:
 

--- a/lib/property_table/table.ex
+++ b/lib/property_table/table.ex
@@ -116,10 +116,6 @@ defmodule PropertyTable.Table do
   """
   @spec put(PropertyTable.table_id(), PropertyTable.property(), PropertyTable.value()) ::
           :ok | {:error, Exception.t()}
-  def put(table, property, nil) do
-    clear(table, property)
-  end
-
   def put(table, property, value) do
     GenServer.call(server_name(table), {:put, property, value, System.monotonic_time()})
   end

--- a/test/property_table_test.exs
+++ b/test/property_table_test.exs
@@ -109,15 +109,12 @@ defmodule PropertyTableTest do
     refute_receive _
   end
 
-  test "setting properties to nil clears them", %{test: table} do
+  test "properties can be set to nil", %{test: table} do
     {:ok, _pid} = start_supervised({PropertyTable, name: table})
     property = ["test"]
 
-    PropertyTable.put(table, property, 124)
-    assert PropertyTable.get_all(table) == [{property, 124}]
-
     PropertyTable.put(table, property, nil)
-    assert PropertyTable.get_all(table) == []
+    assert PropertyTable.get_all(table) == [{property, nil}]
   end
 
   test "subscribing from one process to multiple patterns", %{test: table} do


### PR DESCRIPTION
Storing `nil` in a table can be useful for maintaining timestamps on
properties that come and go. This also matches the semantics of other
Elixir KV stores with regards to `nil`, so hopefully it better matches
people's expectations when using `PropertyTable`.

This feature originated since events generated from setting a property
the first time, clearing it, and setting it to `nil` were ambigous.
Setting properties the first time stopped being ambigous when timestamps
were added. If it becomes to disambiguate clear the property from
setting it to `nil`, then that could be fixed by adding a "reason" field
to the events.
