### PR TITLE
Raise on argument error to put

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ calling `PropertyTable.start_link/1`:
 PropertyTable.start_link(name: NetworkTable)
 ```
 
-Inserting values into the table looks like:
+Inserting properties into the table looks like:
 
 ```elixir
 PropertyTable.put(NetworkTable, ["available_interfaces"], ["eth0", "eth1"])
@@ -71,10 +71,6 @@ PropertyTable.put(NetworkTable, ["connection"], :internet)
 PropertyTable.put(NetworkTable, ["interface", "eth0", "config"], %{ipv4: %{method: :dhcp}})
 PropertyTable.put(NetworkTable, ["interface", "eth0", "connection"], :internet)
 ```
-
-Values can be any Elixir data structure except for `nil`. `nil` is used to
-identify non-existent properties. Therefore, setting a property to `nil` deletes
-the property. You can also call `PropertyTable.clear/2` to delete a property.
 
 Read one property by running:
 

--- a/lib/property_table.ex
+++ b/lib/property_table.ex
@@ -165,7 +165,7 @@ defmodule PropertyTable do
   @doc """
   Update a property and notify listeners
   """
-  @spec put(table_id(), property(), value()) :: :ok | {:error, Exception.t()}
+  @spec put(table_id(), property(), value()) :: :ok
   defdelegate put(table, property, value), to: Table
 
   @doc """

--- a/lib/property_table/table.ex
+++ b/lib/property_table/table.ex
@@ -114,10 +114,12 @@ defmodule PropertyTable.Table do
 
   If the property changed, this will send events to all listeners.
   """
-  @spec put(PropertyTable.table_id(), PropertyTable.property(), PropertyTable.value()) ::
-          :ok | {:error, Exception.t()}
+  @spec put(PropertyTable.table_id(), PropertyTable.property(), PropertyTable.value()) :: :ok
   def put(table, property, value) do
-    GenServer.call(server_name(table), {:put, property, value, System.monotonic_time()})
+    case GenServer.call(server_name(table), {:put, property, value, System.monotonic_time()}) do
+      :ok -> :ok
+      {:error, exception} -> raise exception
+    end
   end
 
   @doc """

--- a/lib/property_table/table.ex
+++ b/lib/property_table/table.ex
@@ -116,10 +116,6 @@ defmodule PropertyTable.Table do
   """
   @spec put(PropertyTable.table_id(), PropertyTable.property(), PropertyTable.value()) ::
           :ok | {:error, Exception.t()}
-  def put(table, property, nil) do
-    clear(table, property)
-  end
-
   def put(table, property, value) do
     GenServer.call(server_name(table), {:put, property, value, System.monotonic_time()})
   end

--- a/test/property_table_test.exs
+++ b/test/property_table_test.exs
@@ -109,15 +109,12 @@ defmodule PropertyTableTest do
     refute_receive _
   end
 
-  test "setting properties to nil clears them", %{test: table} do
+  test "properties can be set to nil", %{test: table} do
     {:ok, _pid} = start_supervised({PropertyTable, name: table})
     property = ["test"]
 
-    PropertyTable.put(table, property, 124)
-    assert PropertyTable.get_all(table) == [{property, 124}]
-
     PropertyTable.put(table, property, nil)
-    assert PropertyTable.get_all(table) == []
+    assert PropertyTable.get_all(table) == [{property, nil}]
   end
 
   test "subscribing from one process to multiple patterns", %{test: table} do

--- a/test/property_table_test.exs
+++ b/test/property_table_test.exs
@@ -335,8 +335,8 @@ defmodule PropertyTableTest do
 
     PropertyTable.subscribe(table, [])
 
-    # Bad property returns error
-    assert {:error, _} = PropertyTable.put(table, [:bad], 90)
+    # Bad property raises
+    assert_raise ArgumentError, fn -> PropertyTable.put(table, [:bad], 90) end
 
     # Doesn't send event
     refute_receive _


### PR DESCRIPTION
`PropertyTable.put/3` used to return an error if the property didn't comform to
what the `Matcher` implementation expected. This turned out to be really
annoying with Dialyzer in that you had to check the return value every single
time you used `put`. Since messing up a property feels like it a programming
error most of the time, using an exception here seems like a better choice.

