### PR TITLE
Rename clear to delete

### DIFF
--- a/lib/property_table.ex
+++ b/lib/property_table.ex
@@ -171,12 +171,12 @@ defmodule PropertyTable do
   @doc """
   Delete the specified property
   """
-  @spec clear(table_id(), property()) :: :ok
-  defdelegate clear(table, property), to: Table
+  @spec delete(table_id(), property()) :: :ok
+  defdelegate delete(table, property), to: Table
 
   @doc """
-  Clear out all properties that match a pattern
+  Delete all properties that match a pattern
   """
-  @spec clear_all(table_id(), pattern()) :: :ok
-  defdelegate clear_all(table, pattern), to: Table
+  @spec delete_matches(table_id(), pattern()) :: :ok
+  defdelegate delete_matches(table, pattern), to: Table
 end

--- a/lib/property_table/table.ex
+++ b/lib/property_table/table.ex
@@ -123,21 +123,19 @@ defmodule PropertyTable.Table do
   end
 
   @doc """
-  Clear a property
-
-  If the property changed, this will send events to all listeners.
+  Delete a property
   """
-  @spec clear(PropertyTable.table_id(), PropertyTable.property()) :: :ok
-  def clear(table, property) do
-    GenServer.call(server_name(table), {:clear, property, System.monotonic_time()})
+  @spec delete(PropertyTable.table_id(), PropertyTable.property()) :: :ok
+  def delete(table, property) do
+    GenServer.call(server_name(table), {:delete, property, System.monotonic_time()})
   end
 
   @doc """
-  Clear out all of the properties under a prefix
+  Delete every property that matches the pattern
   """
-  @spec clear_all(PropertyTable.table_id(), PropertyTable.pattern()) :: :ok
-  def clear_all(table, pattern) do
-    GenServer.call(server_name(table), {:clear_all, pattern, System.monotonic_time()})
+  @spec delete_matches(PropertyTable.table_id(), PropertyTable.pattern()) :: :ok
+  def delete_matches(table, pattern) do
+    GenServer.call(server_name(table), {:delete_matches, pattern, System.monotonic_time()})
   end
 
   @impl GenServer
@@ -189,7 +187,7 @@ defmodule PropertyTable.Table do
   end
 
   @impl GenServer
-  def handle_call({:clear, property, timestamp}, _from, state) do
+  def handle_call({:delete, property, timestamp}, _from, state) do
     case :ets.take(state.table, property) do
       [{_property, previous_value, last_change}] ->
         event = %Event{
@@ -211,7 +209,7 @@ defmodule PropertyTable.Table do
   end
 
   @impl GenServer
-  def handle_call({:clear_all, pattern, timestamp}, _from, state) do
+  def handle_call({:delete_matches, pattern, timestamp}, _from, state) do
     to_delete = match_with_timestamp(state.table, pattern)
 
     # Delete everything first and then send notifications so

--- a/test/property_table_test.exs
+++ b/test/property_table_test.exs
@@ -24,11 +24,11 @@ defmodule PropertyTableTest do
       start_supervised({PropertyTable, properties: [{property1, 1}, {property2, 2}], name: table})
 
     assert PropertyTable.get(table, property1) == 1
-    PropertyTable.clear(table, property1)
+    PropertyTable.delete(table, property1)
     assert PropertyTable.get(table, property1) == nil
 
-    # Redundant clear does nothing
-    PropertyTable.clear(table, property1)
+    # Redundant delete does nothing
+    PropertyTable.delete(table, property1)
 
     assert PropertyTable.get_all(table) == [{property2, 2}]
   end
@@ -100,7 +100,7 @@ defmodule PropertyTableTest do
     PropertyTable.put(table, property, 100)
     assert_receive %Event{table: ^table, property: ^property, value: 100, previous_value: 99}
 
-    PropertyTable.clear(table, property)
+    PropertyTable.delete(table, property)
     assert_receive %Event{table: ^table, property: ^property, value: nil, previous_value: 100}
 
     PropertyTable.unsubscribe(table, property)
@@ -138,13 +138,13 @@ defmodule PropertyTableTest do
     # Check that unsubscribing to one doesn't stop notifications to the other
     PropertyTable.unsubscribe(table, property1)
 
-    PropertyTable.clear(table, property1)
+    PropertyTable.delete(table, property1)
     refute_receive _
     PropertyTable.put(table, property2, 102)
     assert_receive %Event{table: ^table, property: ^property2, value: 102, previous_value: 100}
 
     PropertyTable.unsubscribe(table, property2)
-    PropertyTable.clear(table, property2)
+    PropertyTable.delete(table, property2)
     refute_receive _
   end
 
@@ -239,7 +239,7 @@ defmodule PropertyTableTest do
     PropertyTable.put(table, ["a", "b", "e"], 3)
     PropertyTable.put(table, ["f", "g"], 4)
 
-    PropertyTable.clear_all(table, ["a"])
+    PropertyTable.delete_matches(table, ["a"])
     assert PropertyTable.get_all(table) == [{["f", "g"], 4}]
   end
 


### PR DESCRIPTION
Other Elixir libraries use the word "delete" rather than "clear", so
this renames them for consistency.
