### PR TITLE
Add put_many/2

### DIFF
--- a/lib/property_table.ex
+++ b/lib/property_table.ex
@@ -169,6 +169,15 @@ defmodule PropertyTable do
   defdelegate put(table, property, value), to: Table
 
   @doc """
+  Update many properties
+
+  This is similar to calling `put/3` several times in a row, but atomically. It is
+  also slightly more efficient when updating more than one property.
+  """
+  @spec put_many(table_id(), [{property(), value()}]) :: :ok
+  defdelegate put_many(table, properties), to: Table
+
+  @doc """
   Delete the specified property
   """
   @spec delete(table_id(), property()) :: :ok


### PR DESCRIPTION
This addresses scenarios where many properties are being updated at the
same time. It has the following features:

1. Updates are atomic
2. Notifications only get sent on properties that change
3. If a property is changed multiple times, only the final change is
   used

This scenario comes up a few places in VintageNet libraries.
