### PR TITLE
Rename Table module to Updater and move reader code

### DIFF
--- a/lib/property_table/supervisor.ex
+++ b/lib/property_table/supervisor.ex
@@ -13,11 +13,11 @@ defmodule PropertyTable.Supervisor do
       tuple_events: options.tuple_events
     }
 
-    PropertyTable.Table.create_ets_table(options.table, options.properties)
+    PropertyTable.Updater.create_ets_table(options.table, options.properties)
 
     children = [
       {Registry, [keys: :duplicate, name: registry_name, partitions: 1]},
-      {PropertyTable.Table, table_options}
+      {PropertyTable.Updater, table_options}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/test/property_table_test.exs
+++ b/test/property_table_test.exs
@@ -53,7 +53,7 @@ defmodule PropertyTableTest do
     # Crash the table. Due to async process crash and recovery if there isn't a
     # sleep here, the asserts can run before the crash and pass without testing
     # recovery.
-    table_genserver = PropertyTable.Table.server_name(table)
+    table_genserver = PropertyTable.Updater.server_name(table)
     Process.exit(Process.whereis(table_genserver), :oops)
     Process.sleep(10)
 


### PR DESCRIPTION
This change makes it more obvious what the role of Table (aka Updater)
is: anything that wants to change the contents of a property table
must end up going through this module. All writes are in here.

This change also moves almost all reads of the table out. This removes
the need for many defdelegates with their repeated docs and specs.

This doesn't add or remove any functionality.
